### PR TITLE
Use hash fragments, which are more private

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
 
               link.addEventListener( 'click', protect );
               link.setAttribute( 'data-name', name );
-              link.href = window.location.protocol + '//' + window.location.host + pairingPath + pairingQueryString;
+              link.href = window.location.protocol + '//' + window.location.host + pairingPath + pairingHashFragment;
               link.target = '_blank';
               link.innerText = link.href;
 

--- a/pairing.html
+++ b/pairing.html
@@ -127,13 +127,13 @@
 
         <script>
 
-            var queryString = _.chain( location.search.slice( 1 ).split( /&/g ) )
+                var hashString = _.chain(location.hash.slice(1).split(/&/g))
                 .map( function ( item ) { if ( item ) return item.split( /=/ ).map( function ( str ) { return decodeURIComponent( str ); } ); } )
                 .compact().object().value();
 
-            var name = queryString.name;
+                var name = hashString.name;
 
-            var pairing = CryptoJS.AES.decrypt( queryString.pairing, queryString.key ).toString(CryptoJS.enc.Utf8);
+                var pairing = CryptoJS.AES.decrypt(hashString.pairing, hashString.key).toString(CryptoJS.enc.Utf8);
             var pairingDefinition = pairing.match( /^([^(]+)(?: (\([^)]+\)))?$/ );
 
         </script>


### PR DESCRIPTION
Hey there! 👋 Thanks so much for creating this app! 😄 It's a great little tool for organizing my friends' Secret Santa exchange, and way better than forking over personal data to all of the wacky sites you'll find on Google.

This tool is _almost_ perfect in my eyes, but in the name of bolstering user privacy even more, I'm submitting this PR -- the reason being, hash fragments are more secure than search parameters for transmitting data to another user when said data doesn't require processing on the server (because hash fragments [are never transmitted to the server in the first place](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web#:~:text=It%20is%20worth%20noting%20that,the%20server%20with%20the%20request.)).

This means that the key and encrypted data never leaves the user's browser. Now, do I think GitHub is digging through GitHub Pages request logs to look through this information? No, but they could -- and so could the users' ISPs, or Internet cafes, or malicious users at said Internet cafes (because the site does not require HTTPS; [please enable that, it's just one click!](https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https#enforcing-https-for-your-github-pages-site)).

It's a small change, and it functions identically to the current version, but it doesn't result in sending users' sensitive data over the internet 😊 (this matters less for IRL Secret Santas, but I'm using this with some online friends, and want to be sensitive with their addresses, which will be included as part of the "extra info" in the app).

Thanks so much for your time!