### PR TITLE
Fix "failed to load config from vite.config.tx"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install Dependencies
         run: corepack enable && yarn

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
 
       - name: Install Dependencies
         run: corepack enable && yarn

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build
         run: yarn vite build
+        env:
+          VITE_BASE_URL: '/${{ github.event.repository.name }}'
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Build
         run: yarn vite build
-        env:
-          VITE_BASE_URL: '/${{ github.event.repository.name }}'
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
-import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  base: '/secretsanta/',
-  plugins: [react()],
-}) 
+export default (async () => {
+  const { defineConfig } = await import('vite');
+  return defineConfig({
+    base: '/secretsanta/',
+    plugins: [react()],
+  })
+})();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 export default (async () => {
   const { defineConfig } = await import('vite');
   return defineConfig({
-    base: '/secretsanta/',
+    base: '/',
     plugins: [react()],
   })
 })();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 export default (async () => {
   const { defineConfig } = await import('vite');
   return defineConfig({
-    base: '/',
+    base: '/secretsanta',
     plugins: [react()],
   })
 })();


### PR DESCRIPTION
Mentioned here: https://github.com/arcanis/secretsanta/issues/42#issuecomment-3419563977 

```
yarn vite build
failed to load config from /home/augie/Gits/secretsanta/vite.config.ts
error during build:
Error: require() of ES Module /home/augie/Gits/secretsanta/.yarn/__virtual__/vite-virtual-f6c7aab008/3/.yarn/berry/cache/vite-npm-6.0.0-e468a78b8a-10c0.zip/node_modules/vite/dist/node/index.js from /home/augie/Gits/secretsanta/vite.config.ts not supported.
Instead change the require of index.js in /home/augie/Gits/secretsanta/vite.config.ts to a dynamic import() which is available in all CommonJS modules.
    at require$$0.Module._extensions..js (/home/augie/Gits/secretsanta/.pnp.cjs:9544:15)
    at _require.extensions.<computed> [as .js] (file:///home/augie/Gits/secretsanta/.yarn/__virtual__/vite-virtual-f6c7aab008/3/.yarn/berry/cache/vite-npm-6.0.0-e468a78b8a-10c0.zip/node_modules/vite/dist/node/chunks/dep-C6qYk3zB.js:53565:9)
    at Module.load (node:internal/modules/cjs/loader:1266:32)
    at Module._load (node:internal/modules/cjs/loader:1091:12)
    at require$$0.Module._load (/home/augie/Gits/secretsanta/.pnp.cjs:9396:31)
    at Module.require (node:internal/modules/cjs/loader:1289:19)
    at require (node:internal/modules/helpers:182:18)
    at Object.<anonymous> (/home/augie/Gits/secretsanta/vite.config.ts:36:19)
    at Module._compile (node:internal/modules/cjs/loader:1521:14)
    at _require.extensions.<computed> [as .js] (file:///home/augie/Gits/secretsanta/.yarn/__virtual__/vite-virtual-f6c7aab008/3/.yarn/berry/cache/vite-npm-6.0.0-e468a78b8a-10c0.zip/node_modules/vite/dist/node/chunks/dep-C6qYk3zB.js:53563:16)
```